### PR TITLE
Support models in subfolders

### DIFF
--- a/nodes/minimax_h3_latent_upscaler_2d.py
+++ b/nodes/minimax_h3_latent_upscaler_2d.py
@@ -9,7 +9,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import os
-import glob
 import folder_paths
 import re
 from einops import rearrange
@@ -269,11 +268,11 @@ def get_models_dir():
     return folder_paths.get_folder_paths(_LATENT_UPSCALE_FOLDER)[0]
 
 def scan_models():
-    files = []
     model_dir = get_models_dir()
-    for ext in ("*.pth", "*.safetensors"):
-        files.extend(glob.glob(os.path.join(model_dir, ext)))
-    names = sorted(os.path.basename(f) for f in files)
+    names = [
+        name for name in folder_paths.get_filename_list(_LATENT_UPSCALE_FOLDER)
+        if os.path.splitext(name)[1].lower() in (".pth", ".safetensors")
+    ]
     return names if names else [f"(请将模型放入: {model_dir})"]
 
 def _load_raw_sd(path):
@@ -360,9 +359,7 @@ def load_model(name, device, precision):
     if cache_key in MODEL_CACHE:
         return MODEL_CACHE[cache_key]
 
-    path = os.path.join(get_models_dir(), name)
-    if not os.path.exists(path):
-        raise FileNotFoundError(f"模型文件不存在: {path}")
+    path = folder_paths.get_full_path_or_raise(_LATENT_UPSCALE_FOLDER, name)
 
     raw_sd = _load_raw_sd(path)
     up_sd = _extract_upscaler_sd(raw_sd)

--- a/nodes/minimax_h3_latent_upscaler_3d.py
+++ b/nodes/minimax_h3_latent_upscaler_3d.py
@@ -13,7 +13,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import os
-import glob
 import folder_paths
 import re
 from einops import rearrange
@@ -351,11 +350,11 @@ def get_models_dir():
     return folder_paths.get_folder_paths(_LATENT_UPSCALE_FOLDER)[0]
 
 def scan_models():
-    files = []
     model_dir = get_models_dir()
-    for ext in ("*.pth", "*.safetensors"):
-        files.extend(glob.glob(os.path.join(model_dir, ext)))
-    names = sorted(os.path.basename(f) for f in files)
+    names = [
+        name for name in folder_paths.get_filename_list(_LATENT_UPSCALE_FOLDER)
+        if os.path.splitext(name)[1].lower() in (".pth", ".safetensors")
+    ]
     return names if names else [f"(place models in: {model_dir})"]
 
 def _load_raw_sd(path):
@@ -421,9 +420,7 @@ def load_model(name, device, precision):
         print(f"[MinimaxH3-3D] 🔄 Loading model from cache to {device}")
         return model.to(device)
 
-    path = os.path.join(get_models_dir(), name)
-    if not os.path.exists(path):
-        raise FileNotFoundError(f"Model file not found: {path}")
+    path = folder_paths.get_full_path_or_raise(_LATENT_UPSCALE_FOLDER, name)
 
     raw_sd = _load_raw_sd(path)
     up_sd = _extract_upscaler_sd(raw_sd)


### PR DESCRIPTION
## Summary
- discover `.pth` and `.safetensors` models recursively through ComfyUI's model-folder API
- preserve relative subfolder names in the dropdown
- resolve selected files through `get_full_path_or_raise` for both 2D and 3D nodes

## Tests
- compiled both node modules with `py_compile`
- verified both nodes discover and resolve real models stored under `latent_upscale_models/MiniMaxH3/`