### PR TITLE
为 3D 放大节点增加可调时序分块大小，降低 8GB 显卡 Conv3D 峰值

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ roughly the same as generating high-res directly. The benefit is purely faster t
 | `align` | INT | 32 | 1 – 512 | Pixel-grid alignment: output W/H are independently rounded to multiples of this value (e.g. 16/32/64) |
 | `enable_temporal_chunking` | BOOLEAN | True | True / False | Split long videos into temporal chunks to cap VRAM; disable for short clips for full-context inference |
 | `force_unload` | BOOLEAN | True | True / False | Unload model to CPU after inference to free VRAM for subsequent nodes; disable if you reuse this node repeatedly to avoid reload overhead |
+| `temporal_chunk_frames` | dropdown | 32 | 4 / 8 / 12 / 24 / 32 | Latent frames per temporal chunk; lower values reduce Conv3D peak VRAM at the cost of additional passes |
 | `device` | dropdown | cuda | cuda / rocm / cpu | Inference backend (ROCm needs a HIP-enabled PyTorch build) |
 | `precision` | dropdown | fp32 | fp32 / fp16 / bf16 | Inference precision |
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -211,6 +211,7 @@ ComfyUI/models/latent_upscale_models/
 | `align` | INT | 32 | 1 – 512 | 像素网格对齐：输出 W/H 会分别独立取整到该值的倍数（如 16/32/64） |
 | `enable_temporal_chunking` | BOOLEAN | True | True / False | 长视频时间分块以压低显存峰值；短片段可关闭，使用全上下文推理 |
 | `force_unload` | BOOLEAN | True | True / False | 推理后将模型卸载到 CPU，为后续节点释放显存；若重复使用本节点可关闭，避免重复加载开销 |
+| `temporal_chunk_frames` | 下拉框 | 32 | 4 / 8 / 12 / 24 / 32 | 每个时间分块处理的 latent 帧数；数值越小，Conv3D 峰值显存越低，但处理次数越多 |
 | `device` | 下拉框 | cuda | cuda / rocm / cpu | 推理后端（ROCm 需要支持 HIP 的 PyTorch 构建） |
 | `precision` | 下拉框 | fp32 | fp32 / fp16 / bf16 | 推理精度 |
 

--- a/nodes/minimax_h3_latent_upscaler_3d.py
+++ b/nodes/minimax_h3_latent_upscaler_3d.py
@@ -241,7 +241,8 @@ class LatentResizer3D(nn.Module):
         self.norm_out = normalization(channels)
         self.conv_out = nn.Conv3d(channels, in_channels, 3, padding=1)
 
-    def forward(self, x, scale=None, target_size=None, enable_chunking=True):
+    def forward(self, x, scale=None, target_size=None, enable_chunking=True,
+                temporal_chunk_frames=32):
         if target_size is not None:
             size = target_size
         elif scale is not None:
@@ -261,7 +262,7 @@ class LatentResizer3D(nn.Module):
                 break
 
         overlap = tk
-        chunk = 32
+        chunk = max(1, int(temporal_chunk_frames))
 
         if not enable_chunking or T <= chunk:
             return self._forward_seg(x, scale, size)
@@ -505,6 +506,13 @@ class MinimaxH3LatentUpscaler3D(io.ComfyNode):
                                  tooltip="Unload model to CPU after inference to free VRAM for subsequent nodes. "
                                          "Disable if you run this node repeatedly to avoid reload overhead."),
 
+                io.Combo.Input(
+                    "temporal_chunk_frames",
+                    options=["4", "8", "12", "24", "32"],
+                    default="32",
+                    tooltip="Latent frames processed per temporal chunk. Smaller values reduce Conv3D peak VRAM but require more passes.",
+                ),
+
                 # ---- 硬件 / 精度选项组 ----
                 io.Combo.Input("device", options=["cuda", "rocm", "cpu"], default="cuda"),
                 io.Combo.Input("precision", options=["fp32", "fp16", "bf16"], default="fp16"),
@@ -517,7 +525,7 @@ class MinimaxH3LatentUpscaler3D(io.ComfyNode):
     @classmethod
     def execute(cls, latent: dict, model_name: str, mode: UpscaleConfig,
                 align: int, enable_temporal_chunking: bool, force_unload: bool,
-                device: str, precision: str) -> io.NodeOutput:
+                temporal_chunk_frames: str, device: str, precision: str) -> io.NodeOutput:
 
         if model_name.startswith('('):
             raise ValueError("Please place model files into the latent_upscale_models directory")
@@ -586,7 +594,8 @@ class MinimaxH3LatentUpscaler3D(io.ComfyNode):
             del s
 
             out = model(s_norm, scale=effective_scale, target_size=(t, h_out, w_out),
-                        enable_chunking=enable_temporal_chunking)
+                        enable_chunking=enable_temporal_chunking,
+                        temporal_chunk_frames=int(temporal_chunk_frames))
 
             del s_norm
             out = out * norm_std + norm_mean


### PR DESCRIPTION
## 背景

目前 3D latent 放大节点把时序分块大小固定为 32。对于显存较小的显卡，分块再加上前后 overlap 后，单次 Conv3D 的激活峰值仍可能超过显存。

本地复现环境：

- NVIDIA RTX 4060 8GB
- 输入 latent：`[1, 24, 37, 22, 38]`
- 2 倍放大：`608×352 → 1216×704`
- BF16，时序分块已开启
- 分块 32 时在 `_forward_seg()` 的 `Conv3D` 处 OOM

这与 #18 中反馈的长视频 3D Conv 激活峰值问题属于同一类情况。

## 改动

- 为 `MinimaxH3LatentUpscaler3D` 增加 `temporal_chunk_frames` 下拉选项：`4 / 8 / 12 / 24 / 32`。
- 默认值仍为 `32`，因此没有修改现有默认行为。
- 将选定值传入 `LatentResizer3D.forward()`，只替换原来写死的 `chunk = 32`。
- 完整保留现有的零拷贝加载、`.contiguous()`、`soft_empty_cache`、异步传输、子目录模型扫描和 `force_unload` 等优化。
- 更新中英文参数说明。

较小的分块可以降低 Conv3D 峰值显存，但会增加分块次数和运行时间。

## 验证

- `py_compile` 通过。
- 在 RTX 4060 8GB 上使用与失败任务相同的 latent 形状、2 倍尺寸和 BF16，设置 `temporal_chunk_frames=12`：
  - 4 个时间分块完成
  - 输出计算完成，无 OOM
  - PyTorch 峰值分配显存约 `3942.4 MiB`
  - 独立放大探针耗时约 `9.70 秒`

这个参数让 8GB 用户可以按视频长度和目标分辨率主动降低分块大小，同时保持 32 作为原有默认值。
